### PR TITLE
Fix  - changing VPC setting from Dedicated to Default.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
 
 resource "aws_vpc" "main" {
   cidr_block       = "${var.default_cidr}"
-  instance_tenancy = "dedicated"
+  instance_tenancy = "default"
 
   tags = {
     Name = "${var.vpc_name}"


### PR DESCRIPTION
Changing the VPC setting from Dedicated to Default.  This should reduce cost and AMI size requirements.